### PR TITLE
New Feature: Custom Treasury - Accepted Tokens LIst

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ cosm-orc = { version = "4.0" }
 cosm-tome = "0.2"
 cosmos-sdk-proto = "0.19"
 cosmwasm-schema = { version = "1.2" }
-cosmwasm-std = { version = "1.5.0", features = ["ibc3", "cosmwasm_1_3"] }
+cosmwasm-std = { version = "1.5.0", features = ["ibc3"] }
 cw-controllers = "1.1"
 cw-multi-test = "0.18"
 cw-storage-plus = { version = "1.1" }

--- a/contracts/dao-dao-core/src/contract.rs
+++ b/contracts/dao-dao-core/src/contract.rs
@@ -1,12 +1,11 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_json, to_json_binary, Addr, BankQuery, Binary, Coin, CosmosMsg, Deps, DepsMut,
-    DistributionMsg, Empty, Env, MessageInfo, Order, Reply, Response, StdError, StdResult, SubMsg,
+    from_json, to_json_binary, Addr, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Deps, DepsMut,
+     Empty, Env, MessageInfo, Order, Reply, Response, StdError, StdResult, SubMsg,
     WasmMsg,
 };
 use cw2::{get_contract_version, set_contract_version, ContractVersion};
-use cw20::Cw20ExecuteMsg;
 use cw_paginate_storage::{paginate_map, paginate_map_keys, paginate_map_values};
 use cw_storage_plus::Map;
 use cw_utils::{parse_reply_instantiate_data, Duration};
@@ -440,24 +439,16 @@ fn do_update_token_list(
     map: Map<String, Empty>,
     to_add: Vec<String>,
     to_remove: Vec<String>,
-    verify: impl Fn(&String, Deps) -> StdResult<()>,
 ) -> Result<(), ContractError> {
-    let to_add = to_add
-        .into_iter()
-        .map(|a| a)
-        .collect::<Vec<String>>();
+    let to_add = to_add.into_iter().map(|a| a).collect::<Vec<String>>();
 
-    let to_remove = to_remove
-        .into_iter()
-        .map(|a| a)
-        .collect::<Vec<String>>();
+    let to_remove = to_remove.into_iter().map(|a| a).collect::<Vec<String>>();
 
-    for addr in to_add {
-        verify(&addr, deps.as_ref())?;
-        map.save(deps.storage, addr, &Empty {})?;
+    for token in to_add {
+        map.save(deps.storage, token, &Empty {})?;
     }
-    for addr in to_remove {
-        map.remove(deps.storage, addr);
+    for token in to_remove {
+        map.remove(deps.storage, token);
     }
 
     Ok(())
@@ -516,18 +507,7 @@ pub fn execute_update_token_list(
     if env.contract.address != sender {
         return Err(ContractError::Unauthorized {});
     }
-    do_update_token_list(
-        deps,
-        ACCEPTED_NATIVE_TOKENS,
-        to_add,
-        to_remove,
-        |addr, deps| {
-            let _info: cw721::ContractInfoResponse = deps
-                .querier
-                .query_wasm_smart(addr, &cw721::Cw721QueryMsg::ContractInfo {})?;
-            Ok(())
-        },
-    )?;
+    do_update_token_list(deps, ACCEPTED_NATIVE_TOKENS, to_add, to_remove)?;
     Ok(Response::default().add_attribute("action", "update_cw721_list"))
 }
 
@@ -664,6 +644,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::GetItem { key } => query_get_item(deps, key),
         QueryMsg::Info {} => query_info(deps),
         QueryMsg::ListItems { start_after, limit } => query_list_items(deps, start_after, limit),
+        QueryMsg::NativeTokenList { start_after, limit } => {
+            query_native_token_list(deps, start_after, limit)
+        }
         QueryMsg::PauseInfo {} => query_paused(deps, env),
         QueryMsg::ProposalModules { start_after, limit } => {
             query_proposal_modules(deps, start_after, limit)
@@ -847,6 +830,20 @@ pub fn query_list_items(
     )?)
 }
 
+pub fn query_native_token_list(
+    deps: Deps,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> StdResult<Binary> {
+    to_json_binary(&paginate_map_keys(
+        deps,
+        &ACCEPTED_NATIVE_TOKENS,
+        start_after.clone(),
+        limit,
+        cosmwasm_std::Order::Descending,
+    )?)
+}
+
 pub fn query_cw20_list(
     deps: Deps,
     start_after: Option<String>,
@@ -981,8 +978,8 @@ pub fn remove_unwanted_balance(
         .filter(|coin: &Coin| !is_denom_accepted(&coin.denom, &accepted_native_tokens))
         .collect();
 
-    // send all unwanted_native_tokens to the treasury
-    let send_to_community_pool = DistributionMsg::FundCommunityPool {
+    // burn all unwanted tokens from treasury
+    let send_to_community_pool = BankMsg::Burn {
         amount: unwanted_native_tokens,
     };
 

--- a/contracts/dao-dao-core/src/contract.rs
+++ b/contracts/dao-dao-core/src/contract.rs
@@ -2,8 +2,7 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     from_json, to_json_binary, Addr, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Deps, DepsMut,
-     Empty, Env, MessageInfo, Order, Reply, Response, StdError, StdResult, SubMsg,
-    WasmMsg,
+    Empty, Env, MessageInfo, Order, Reply, Response, StdError, StdResult, SubMsg, WasmMsg,
 };
 use cw2::{get_contract_version, set_contract_version, ContractVersion};
 use cw_paginate_storage::{paginate_map, paginate_map_keys, paginate_map_values};
@@ -956,6 +955,10 @@ pub fn remove_unwanted_balance(
     env: Env,
     start_after: Option<String>,
 ) -> Result<Response, ContractError> {
+    // runs every 4 hours
+    if env.block.height % 4800 != 0 {
+        return Ok(Response::new());
+    };
     let contract = env.contract.address;
     // Query bank for contract balance of native denoms
     let native_balance: cosmwasm_std::AllBalanceResponse =

--- a/contracts/dao-dao-core/src/state.rs
+++ b/contracts/dao-dao-core/src/state.rs
@@ -54,5 +54,7 @@ pub const CW721_LIST: Map<Addr, Empty> = Map::new("cw721s");
 /// treasury
 pub const ACCEPTED_NATIVE_TOKENS: Map<String, Empty> = Map::new("accepted_native_tokens");
 
+pub const CUSTOM_TREASURY_BOOL: Item<bool> = Item::new("custom_treasury_bool");
+
 /// List of SubDAOs associated to this DAO. Each SubDAO has an optional charter.
 pub const SUBDAO_LIST: Map<&Addr, Option<String>> = Map::new("sub_daos");

--- a/contracts/dao-dao-core/src/tests.rs
+++ b/contracts/dao-dao-core/src/tests.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     coin, from_json,
     testing::{mock_dependencies, mock_env},
-    to_json_binary, Addr, CosmosMsg, Empty, Storage, Uint128, WasmMsg,
+    to_json_binary, Addr, BlockInfo, CosmosMsg, Empty, Storage, Uint128, WasmMsg,
 };
 use cw2::{set_contract_version, ContractVersion};
 use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor, SudoMsg, WasmSudo};
@@ -2451,10 +2451,30 @@ fn test_native_token_list() {
     }))
     .unwrap();
 
+    let dao_balance = app.wrap().query_all_balances(gov_addr.clone()).unwrap();
+    assert_eq!(
+        dao_balance,
+        vec![
+            coin(10u128, "hops"),
+            coin(10u128, "pepper"),
+            coin(10u128, "rosemary")
+        ]
+    );
+    app.update_block(|block| block.height += 6855);
+    println!("{}",app.block_info().height);
+
+    app.sudo(SudoMsg::Wasm({
+        WasmSudo {
+            contract_addr: gov_addr.clone(),
+            msg: to_json_binary(&DaoSudoMsg::ClockEndBlock { start_after: None }).unwrap(),
+        }
+    }))
+    .unwrap();
+
     let dao_balance = app.wrap().query_all_balances(gov_addr).unwrap();
     assert_eq!(
         dao_balance,
-        vec![coin(10u128, "hops"), coin(10u128, "rosemary")]
+        vec![coin(10u128, "hops"), coin(10u128, "rosemary"),]
     );
 }
 

--- a/packages/dao-interface/src/msg.rs
+++ b/packages/dao-interface/src/msg.rs
@@ -190,6 +190,12 @@ pub enum QueryMsg {
     /// Returns contract version info
     #[returns(crate::voting::InfoResponse)]
     Info {},
+    // Returns acceped native tokens list
+    #[returns(Vec<String>)]
+    NativeTokenList {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
     /// Gets all proposal modules associated with the
     /// contract.
     #[returns(Vec<crate::state::ProposalModule>)]

--- a/packages/dao-interface/src/msg.rs
+++ b/packages/dao-interface/src/msg.rs
@@ -114,6 +114,7 @@ pub enum ExecuteMsg {
         to_remove: Vec<String>,
     },
     UpdateTokenList {
+        bool: Option<bool>,
         to_add: Vec<String>,
         to_remove: Vec<String>,
     },


### PR DESCRIPTION
Introduces new features for a DAO treasury, where a list of accepted native token strings can be toggled to filter out unwanted tokens. This feature is disabled by default, and can be toggled on with a DAO prop, including a list of token strings to be accepted. 

This feature makes use of the x/clock module, querying the total balance of the DAO from the bank module every 4800 blocks, and burns any token balance not included in the list of accepted tokens. 